### PR TITLE
fix(auto-assign): pass --repo to gh pr edit

### DIFF
--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Request review from feds01
-        run: gh pr edit ${{ github.event.pull_request.number }} --add-reviewer feds01
+        run: gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-reviewer feds01
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The auto-assign-reviewer workflow has been failing since added because `gh pr edit` tries to infer the target repo from git remote, but there is no checkout step. Pass `--repo` explicitly so it works without a checkout.

## Trace
Failure from run 24978874330:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Test plan
- [ ] Wait for next ImgBot PR (or reopen #3) and verify `feds01` is added as reviewer automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)