### PR TITLE
fix: switch README stats to official github-readme-stats instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ ______________________________________________________________________
 
 <p float="left">
 <a href="https://github.com/anuraghazra/github-readme-stats">
-  <img align="top" width="50%" src="https://github-readme-stats-tawny-theta-96.vercel.app/api?username=feds01&include_all_commits=true&theme=dark&show_icons=true" />
+  <img align="top" width="50%" src="https://github-readme-stats.vercel.app/api?username=feds01&include_all_commits=true&theme=dark&show_icons=true" />
 </a>
 <a href="https://github.com/anuraghazra/github-readme-stats">
-  <img align="top" width="49%" src="https://github-readme-stats-tawny-theta-96.vercel.app/api/top-langs/?username=feds01&hide=html,scss&layout=compact&theme=dark" />
+  <img align="top" width="49%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=feds01&hide=html,scss&layout=compact&theme=dark" />
 </a>
 </p>


### PR DESCRIPTION
## What

The README stats and top-languages images pointed at a personal Vercel deployment (`github-readme-stats-tawny-theta-96.vercel.app`) that is no longer available, leaving both images broken.

This switches both image URLs to the official public instance, `github-readme-stats.vercel.app`.

## Why

The previous host is down, so the stats cards no longer render on the profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)